### PR TITLE
Add logging functions to the bindings

### DIFF
--- a/wrapper.h
+++ b/wrapper.h
@@ -1,1 +1,2 @@
 #include <td/telegram/td_json_client.h>
+#include <td/telegram/td_log.h>


### PR DESCRIPTION
Hi!
I think it would be very useful to add the `td_log.h` header to these bindings.
I don't think it makes much sense to do it in a separate crate.