### PR TITLE
Fix warnings and update version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tdjson-sys"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Mike Lubinets <lubinetsm@yandex.ru>"]
 description = "TDLIB Json Client Rust FFI Bindings"
 documentation = "https://docs.rs/crate/tdjson-sys"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
+#![allow(non_camel_case_types)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
Hi!

In the last PR i forgot to include a line to suppress the non_camel_case_type warning.
Also, the library minor version should be increased, so you can update it on crates.io.

I will do the PR in the tdjson-rs repo once this is updated on crates.io.