### PR TITLE
Update bindgen to 0.54.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ categories = ["external-ffi-bindings"]
 
 
 [build-dependencies]
-bindgen = "0.26.3"
+bindgen = "0.54.0"


### PR DESCRIPTION
I can't build the crate with the old bindgen version. Upgrading seems to work